### PR TITLE
fix: no notice when assign-all-tables-block-id has nothing to assign

### DIFF
--- a/src/commands/assign-all-tables-block-id.ts
+++ b/src/commands/assign-all-tables-block-id.ts
@@ -35,10 +35,7 @@ export function assignAllTablesBlockId(plugin: Plugin): void {
 		}
 	}
 
-	if (insertAfterLines.length === 0) {
-		new Notice("No tables without block-id in this note.");
-		return;
-	}
+	if (insertAfterLines.length === 0) return;
 
 	const nextNum = getNextTableNumberInNote(editor);
 	// Insert from bottom to top to keep line numbers valid


### PR DESCRIPTION
When the user runs **Asignar block-id a todas las tablas de esta nota que no tengan** and there are no tables without block-id (or no tables at all), the command now returns silently instead of showing a Notice.

This avoids unnecessary messages in Obsidian when there is nothing to do.

Made with [Cursor](https://cursor.com)